### PR TITLE
Our battery has 1290mAh & disable JIT

### DIFF
--- a/kumquat.mk
+++ b/kumquat.mk
@@ -92,6 +92,5 @@ PRODUCT_PROPERTY_OVERRIDES += \
   ro.hwui.layer_cache_size=7 \
   ro.hwui.path_cache_size=2 \
   ro.sf.lcd_density=240 \
-  ro.config.low_ram=true
-
-
+  ro.config.low_ram=true \
+  dalvik.vm.jit.codecachesize=0

--- a/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -27,5 +27,5 @@
         <value>125</value>
         <value>200</value>
     </array>
-    <item name="battery.capacity">1500</item>
+    <item name="battery.capacity">1290</item>
 </device>


### PR DESCRIPTION
At least my stock Sony battery has 1290mAh :P 

---

Disable JIT due to low RAM: https://source.android.com/devices/low-ram.html#jit
